### PR TITLE
Solve issue with deleted documentation.

### DIFF
--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetPlugin.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetPlugin.scala
@@ -354,10 +354,15 @@ object BiopetPlugin extends AutoPlugin {
     Def.setting {
       new FileFilter {
         def accept(f: File): Boolean = {
+          // Take the relative path, so only values within the
+          // ghpagesRepository are taken into account.
+          val empty: File = new File("")
+          val relativePath = f.relativeTo(ghpagesRepository.value).getOrElse(empty).toString()
           if (isSnapshot.value) {
-            f.getPath.contains("develop")
+            relativePath.contains("develop")
           } else {
-            f.getPath.contains(s"${version.value}") ||
+            relativePath.contains(s"${version.value}") ||
+            // Also index.html needs to deleted to point to a new version.
             f.getPath == new java.io.File(ghpagesRepository.value, "index.html").getPath
           }
         }

--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetPlugin.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetPlugin.scala
@@ -357,7 +357,8 @@ object BiopetPlugin extends AutoPlugin {
           // Take the relative path, so only values within the
           // ghpagesRepository are taken into account.
           val empty: File = new File("")
-          val relativePath = f.relativeTo(ghpagesRepository.value).getOrElse(empty).toString()
+          val relativePath =
+            f.relativeTo(ghpagesRepository.value).getOrElse(empty).toString()
           if (isSnapshot.value) {
             relativePath.contains("develop")
           } else {


### PR DESCRIPTION
The original FileFilter
- checked whether `develop` was in the file path and would delete the develop documentation OR
- checked whether `version.value` was in the file path and would delete the version documentation and the html redirector.

The issue arose by the file path _being absolute_. So if your repository happened to be in `/home/ci/development/biopet/whatever/ `
then always all files would be deleted when on development/SNAPSHOT.

This issue should be solved now.
