### PR TITLE
Refactor sbt-biopet for readability

### DIFF
--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetDocumentationSettings.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetDocumentationSettings.scala
@@ -40,8 +40,8 @@ import nl.biopet.sbtbiopet.BiopetPlugin.autoImport._
 import nl.biopet.utils.Documentation.htmlRedirector
 import ohnosequences.sbt.GithubRelease.keys.TagName
 import sbt.Keys._
+import sbt._
 import sbt.io.IO.relativize
-import sbt.{Attributed, Compile, Def, File, FileFilter, Setting, Task, file}
 import sbtassembly.AssemblyPlugin.autoImport.assembly
 
 object BiopetDocumentationSettings {
@@ -135,10 +135,9 @@ object BiopetDocumentationSettings {
           throw new IllegalStateException(
             "Mainclass should be defined for a tool.")
       }
-      import Attributed.data
       r.run(
         mainClassString,
-        data(classPath),
+        Attributed.data(classPath),
         args,
         streamsLogValue
       )

--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetDocumentationSettings.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetDocumentationSettings.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2017 Sequencing Analysis Support Core - Leiden University Medical Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package nl.biopet.sbtbiopet
+
+import java.io.File
+
+import com.typesafe.sbt.sbtghpages.GhpagesPlugin.autoImport.{
+  ghpagesCleanSite,
+  ghpagesPushSite,
+  ghpagesRepository
+}
+import com.typesafe.sbt.site.SitePlugin.autoImport.{
+  makeSite,
+  siteDirectory,
+  siteSubdirName
+}
+import com.typesafe.sbt.site.SiteScaladocPlugin.autoImport.SiteScaladoc
+import com.typesafe.sbt.site.laika.LaikaSitePlugin.autoImport.LaikaSite
+import laika.sbt.LaikaPlugin.autoImport.{Laika, laikaRawContent}
+import nl.biopet.sbtbiopet.BiopetPlugin.autoImport._
+import nl.biopet.utils.Documentation.htmlRedirector
+import ohnosequences.sbt.GithubRelease.keys.TagName
+import sbt.Keys._
+import sbt.io.IO.relativize
+import sbt.{Attributed, Compile, Def, File, FileFilter, Setting, Task, file}
+import sbtassembly.AssemblyPlugin.autoImport.assembly
+
+object BiopetDocumentationSettings {
+  /*
+   * A sequence of settings related to documentation.
+   * This includes all the settings for
+   *  - LAIKA
+   *  - Ghpagesplugin
+   *  - Our custom documentation generation code
+   *  - SBT-site
+   */
+  def biopetDocumentationSettings: Seq[Setting[_]] = Seq(
+    biopetDocsDir := file(
+      s"%s${File.separator}markdown".format(target.value.toString)),
+    biopetReadmePath := file("README.md").getAbsoluteFile,
+    sourceDirectory in LaikaSite := biopetDocsDir.value,
+    sourceDirectories in Laika := Seq((sourceDirectory in LaikaSite).value),
+    siteDirectory in Laika := file(
+      target.value.toString + s"${File.separator}site"),
+    ghpagesRepository := file(target.value.toString + s"${File.separator}gh"),
+    siteSubdirName in SiteScaladoc := {
+      if (biopetIsTool.value) {
+        if (isSnapshot.value) {
+          s"develop${File.separator}api"
+        } else s"${version.value}${File.separator}api"
+      } else {
+        if (isSnapshot.value) {
+          "develop"
+        } else s"${version.value}"
+      }
+    },
+    laikaRawContent in LaikaSite := true, //Laika use raw HTML content in markdown.
+    includeFilter in ghpagesCleanSite := biopetCleanSiteFilter.value,
+    biopetGenerateDocs := biopetGenerateDocsFunction().value,
+    biopetGenerateReadme := biopetGenerateReadmeFunction().value,
+    makeSite := (makeSite triggeredBy biopetGenerateDocs).value,
+    makeSite := (makeSite dependsOn biopetGenerateDocs).value,
+    ghpagesPushSite := (ghpagesPushSite dependsOn makeSite).value
+  )
+  /*
+   * Accesses the tools main method to generate documentation using our custom built-in documentation function
+   */
+  protected def biopetGenerateDocsFunction(): Def.Initialize[Task[Unit]] =
+    Def.taskDyn {
+      if (biopetIsTool.value) {
+        Def
+          .task[Unit] {
+            val r = (runner in Compile).value
+            val classPath = (fullClasspath in Compile).value
+
+            val streamsLogValue = streams.value.log
+
+            val args = Seq("--generateDocs",
+                           s"outputDir=${biopetDocsDir.value.toString}," +
+                             s"version=${version.value}," +
+                             s"release=${!isSnapshot.value}",
+                           version.value)
+
+            val mainClassString = (mainClass in assembly).value match {
+              case Some(x) => x
+              case _ =>
+                throw new IllegalStateException(
+                  "Mainclass should be defined for a tool.")
+            }
+            import Attributed.data
+            r.run(
+              mainClassString,
+              data(classPath),
+              args,
+              streamsLogValue
+            )
+
+          }
+          .dependsOn(compile in Compile)
+      } else
+        Def.task[Unit] {
+          biopetDocsDir.value.mkdirs()
+          if (!isSnapshot.value) {
+            val htmlRedirectFile: sbt.File =
+              new File(biopetDocsDir.value, "index.html")
+            htmlRedirector(
+              outputFile = htmlRedirectFile,
+              link = s"${version.value}${File.separator}index.html",
+              title = "API documentation",
+              redirectText = "Go to the API documentation")
+          }
+        }
+    }
+
+  /*
+   * Accesses the tools main method to generate a README using our custom built-in documentation function
+   */
+  protected def biopetGenerateReadmeFunction(): Def.Initialize[Task[Unit]] =
+    Def.taskDyn {
+      if (biopetIsTool.value) {
+        Def
+          .task[Unit] {
+            val r = (runner in Compile).value
+            val classPath = (fullClasspath in Compile).value
+
+            val args = Seq("--generateReadme", biopetReadmePath.value.toString)
+
+            val streamsLogValue = streams.value.log
+
+            val mainClassString = (mainClass in assembly).value match {
+              case Some(x) => x
+              case _ =>
+                throw new IllegalStateException(
+                  "Mainclass should be defined for a tool.")
+            }
+            import Attributed.data
+            r.run(
+              mainClassString,
+              data(classPath),
+              args,
+              streamsLogValue
+            )
+
+          }
+          .dependsOn(compile in Compile)
+      } else Def.task[Unit] {}
+    }
+  /*
+   * The filter that is used by the ghpages plugin.
+   * All files in this filter will be removed.
+   * This allows the updating of documentation for a specific version
+   * All other versions will not be touched.
+   */
+  protected def biopetCleanSiteFilter: Def.Initialize[FileFilter] =
+    Def.setting {
+      new FileFilter {
+        def accept(f: File): Boolean = {
+          // Take the relative path, so only values within the
+          // ghpagesRepository are taken into account.
+          val empty: File = new File("")
+          val relativePath: TagName =
+            relativize(ghpagesRepository.value, f).getOrElse(empty).toString
+          if (isSnapshot.value) {
+            relativePath.contains("develop")
+          } else {
+            relativePath.contains(s"${version.value}") ||
+            // Also index.html needs to deleted to point to a new version.
+            f.getPath == new java.io.File(ghpagesRepository.value, "index.html").getPath
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetPlugin.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetPlugin.scala
@@ -21,8 +21,6 @@
 
 package nl.biopet.sbtbiopet
 
-import java.io.File
-
 import com.codacy.CodacyCoveragePlugin
 import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport.{
   scalafmt,
@@ -32,7 +30,6 @@ import com.lucidchart.sbt.scalafmt.ScalafmtSbtPlugin
 import com.lucidchart.sbt.scalafmt.ScalafmtSbtPlugin.autoImport.Sbt
 import com.typesafe.sbt.SbtGit.git
 import com.typesafe.sbt.sbtghpages.GhpagesPlugin
-import com.typesafe.sbt.sbtghpages.GhpagesPlugin.autoImport.ghpagesRepository
 import com.typesafe.sbt.site.laika.LaikaSitePlugin
 import com.typesafe.sbt.site.{SitePlugin, SiteScaladocPlugin}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{
@@ -48,7 +45,6 @@ import nl.biopet.sbtbiopet.BiopetDocumentationSettings._
 import nl.biopet.sbtbiopet.BiopetReleaseSettings._
 import nl.biopet.utils.Documentation.markdownExtractChapter
 import ohnosequences.sbt.SbtGithubReleasePlugin
-import ohnosequences.sbt.SbtGithubReleasePlugin.autoImport._
 import sbt.Keys._
 import sbt.{Def, _}
 import sbtassembly.AssemblyPlugin.autoImport._

--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetReleaseSettings.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetReleaseSettings.scala
@@ -21,17 +21,57 @@
 
 package nl.biopet.sbtbiopet
 
-import nl.biopet.sbtbiopet.BiopetPlugin.autoImport.{
-  biopetIsTool,
-  biopetReleaseInBioconda,
-  biopetReleaseInSonatype
+import com.typesafe.sbt.SbtPgp.autoImportImpl.useGpg
+import nl.biopet.sbtbiopet.BiopetPlugin.autoImport._
+import ohnosequences.sbt.GithubRelease
+import ohnosequences.sbt.GithubRelease.keys._
+import sbt.Keys._
+import sbt.{Def, Opts, Resolver, Setting}
+import sbtassembly.AssemblyPlugin.autoImport.{assembly, assemblyOutputPath}
+import sbtrelease.ReleasePlugin.autoImport.{
+  ReleaseStep,
+  releaseCrossBuild,
+  releaseProcess,
+  releaseStepCommand
 }
-import sbt.Def
-import sbt.Keys.name
-import sbtrelease.ReleasePlugin.autoImport.{ReleaseStep, releaseStepCommand}
 import sbtrelease.ReleaseStateTransformations._
 
 object BiopetReleaseSettings {
+  /*
+   * A sequence of settings specific to release
+   */
+  def biopetReleaseSettings: Seq[Setting[_]] = Seq(
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+    resolvers += Resolver.sonatypeRepo("releases"),
+    releaseCrossBuild := true,
+    publishTo := biopetPublishTo.value,
+    publishMavenStyle := true,
+    useGpg := true,
+    ghreleaseRepoName := biopetUrlName.value,
+    ghreleaseAssets := {
+      val assemblyPath = (assemblyOutputPath in assembly).value
+      if (biopetIsTool.value) Seq(assemblyPath) else Seq()
+    },
+    ghreleaseRepoOrg := githubOrganization.value,
+    //ghreleaseTitle same as upstream default. Specified here to be stable between releases.
+    ghreleaseTitle := { tagName =>
+      s"${name.value} $tagName"
+    },
+    // ghreleaseNotes generic message. (Empty message leads to prompt).
+    ghreleaseNotes := { tagName =>
+      s"Release ${tagName.stripPrefix("v")}"
+    },
+    // ghreleaseGithubToken copied from default for stability.
+    ghreleaseGithubToken := {
+      GithubRelease.defs.githubTokenFromEnv(
+        GithubRelease.defs.defaultTokenEnvVar) orElse
+        GithubRelease.defs.githubTokenFromFile(
+          GithubRelease.defs.defaultTokenFile)
+    },
+    biopetReleaseInBioconda := biopetIsTool.value, // Only release tools in bioconda, not libraries
+    biopetReleaseInSonatype := true,
+    releaseProcess := biopetReleaseProcess.value
+  )
   protected def biopetReleaseStepsStart: Def.Initialize[Seq[ReleaseStep]] = {
     Def.setting[Seq[ReleaseStep]] {
       Seq[ReleaseStep](
@@ -118,4 +158,14 @@ object BiopetReleaseSettings {
         biopetReleaseStepsNextVersion.value
     }
   }
+  /*
+   * Biopet resolver.
+   */
+  protected def biopetPublishTo: Def.Initialize[Option[Resolver]] =
+    Def.setting {
+      if (isSnapshot.value)
+        Some(Opts.resolver.sonatypeSnapshots)
+      else
+        Some(Opts.resolver.sonatypeStaging)
+    }
 }

--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetReleaseSettings.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetReleaseSettings.scala
@@ -31,7 +31,7 @@ import sbt.Keys.name
 import sbtrelease.ReleasePlugin.autoImport.{ReleaseStep, releaseStepCommand}
 import sbtrelease.ReleaseStateTransformations._
 
-object BiopetReleaseSteps {
+object BiopetReleaseSettings {
   protected def biopetReleaseStepsStart: Def.Initialize[Seq[ReleaseStep]] = {
     Def.setting[Seq[ReleaseStep]] {
       Seq[ReleaseStep](

--- a/src/main/scala/nl/biopet/sbtbiopet/BiopetReleaseSteps.scala
+++ b/src/main/scala/nl/biopet/sbtbiopet/BiopetReleaseSteps.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2017 Sequencing Analysis Support Core - Leiden University Medical Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package nl.biopet.sbtbiopet
+
+import nl.biopet.sbtbiopet.BiopetPlugin.autoImport.{
+  biopetIsTool,
+  biopetReleaseInBioconda,
+  biopetReleaseInSonatype
+}
+import sbt.Def
+import sbt.Keys.name
+import sbtrelease.ReleasePlugin.autoImport.{ReleaseStep, releaseStepCommand}
+import sbtrelease.ReleaseStateTransformations._
+
+object BiopetReleaseSteps {
+  protected def biopetReleaseStepsStart: Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      Seq[ReleaseStep](
+        releaseStepCommand("git fetch"),
+        releaseStepCommand("git checkout master"),
+        releaseStepCommand("git pull"),
+        releaseStepCommand("git merge origin/develop"),
+        checkSnapshotDependencies,
+        inquireVersions,
+        runClean,
+        runTest,
+        setReleaseVersion,
+        commitReleaseVersion,
+        tagRelease,
+        pushChanges
+      )
+    }
+  }
+
+  protected def biopetReleaseStepsSonatype: Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      Seq[ReleaseStep](
+        releaseStepCommand(s"sonatypeOpen ${name.value}"),
+        releaseStepCommand("publishSigned"),
+        releaseStepCommand("sonatypeReleaseAll")
+      )
+    }
+  }
+
+  protected def biopetReleaseStepsGithub: Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      Seq[ReleaseStep](
+        releaseStepCommand("ghpagesPushSite"),
+        releaseStepCommand("githubRelease")
+      )
+    }
+  }
+
+  protected def biopetReleaseStepsBioconda: Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      Seq[ReleaseStep](
+        releaseStepCommand(
+          "set biocondaVersion := releaseTagName.value.stripPrefix(\"v\")"), //Dynamically gets the version in the release process.
+        releaseStepCommand("biocondaRelease")
+      )
+    }
+  }
+
+  protected def biopetReleaseStepsAssembly: Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      Seq[ReleaseStep](
+        releaseStepCommand("set test in assembly := {}"),
+        releaseStepCommand("assembly")
+      )
+    }
+  }
+  protected def biopetReleaseStepsNextVersion
+    : Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      Seq[ReleaseStep](
+        releaseStepCommand("git checkout develop"),
+        releaseStepCommand("git merge master"),
+        setNextVersion,
+        commitNextVersion,
+        pushChanges
+      )
+    }
+  }
+  /*
+   * The ReleaseProcess for use with the sbt-release plugin
+   */
+  def biopetReleaseProcess: Def.Initialize[Seq[ReleaseStep]] = {
+    Def.setting[Seq[ReleaseStep]] {
+      biopetReleaseStepsStart.value ++ {
+        if (biopetIsTool.value) biopetReleaseStepsAssembly.value else Seq()
+      } ++ {
+        if (biopetReleaseInSonatype.value) biopetReleaseStepsSonatype.value
+        else Seq()
+      } ++
+        biopetReleaseStepsGithub.value ++ {
+        if (biopetReleaseInBioconda.value) biopetReleaseStepsBioconda.value
+        else Seq()
+      } ++
+        biopetReleaseStepsNextVersion.value
+    }
+  }
+}

--- a/src/sbt-test/common/biopetTest/test
+++ b/src/sbt-test/common/biopetTest/test
@@ -3,3 +3,4 @@
 
 #Check if biopetTest works
 > biopetTest
+> biopetTestReport


### PR DESCRIPTION
Pushed biopetDocumentationSettings and biopetReleaseSettings to their own objects. These were taking a huge portion of lines. Having them in their own objects makes it easier to find the functions related to documentation and release.